### PR TITLE
feat: add Sudoku game to Games tab

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -41,6 +41,72 @@
   color: #888;
 }
 
+.home-logos {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.home-intro {
+  max-width: 640px;
+  margin: 0 auto 1.75rem;
+}
+
+.home-tagline {
+  margin: 0 0 0.5rem;
+  font-size: 1.15rem;
+  font-weight: 700;
+}
+
+.home-description {
+  margin: 0;
+  line-height: 1.6;
+  opacity: 0.85;
+}
+
+.home-links {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.1rem;
+}
+
+.home-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.home-buttons .my-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: #0d6efd;
+  border: 2px solid #0d6efd;
+  background: #fff;
+  text-decoration: none;
+}
+
+.home-buttons .my-button .fa {
+  color: inherit;
+}
+
+.home-buttons .my-button:hover,
+.home-buttons .my-button:focus {
+  color: #fff;
+  background: #0d6efd;
+  box-shadow:
+    0 5px 11px 0 rgba(0, 0, 0, 0.18),
+    0 4px 14px 1px rgba(0, 0, 0, 0.15);
+}
+
+.home-social {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
 .justify {
   flex: 1;
 }

--- a/src/component/Home.jsx
+++ b/src/component/Home.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import reactLogo from "../assets/react.svg";
 import viteLogo from "../assets/vite.svg";
 import ProjectLinks from "./ProjectLinks.jsx";
+
 function Home() {
   const [loading, setLoading] = useState(true);
   useEffect(() => {
@@ -11,62 +12,36 @@ function Home() {
     };
   }, []);
 
-  let loadContent;
-  if (loading) {
-    loadContent = (
-      <output className="spinner-border text-success" aria-live="polite">
-        <span className="sr-only">Loading...</span>
-      </output>
-    );
-  } else {
-    loadContent = <ProjectLinks />;
-  }
-
   return (
-    <div>
-      <div>
-        <a href="https://vitejs.dev" target="_blank">
+    <div className="home">
+      <div className="home-logos">
+        <a href="https://vite.dev" target="_blank" rel="noreferrer">
           <img src={viteLogo} className="logo" alt="Vite logo" />
         </a>
-        <a href="https://reactjs.org" target="_blank">
+        <a href="https://react.dev" target="_blank" rel="noreferrer">
           <img src={reactLogo} className="logo react" alt="React logo" />
         </a>
       </div>
+
       <h1>Vite + React</h1>
-      <br></br>
 
-      {loadContent}
-
-      <div className="footer-div">
-        <p className={"footer-text"}>
-          Experimental page using React
-          <br></br>
-          <a href="https://greentea524.github.io/">
-            https://greentea524.github.io/
-          </a>
+      <div className="home-intro">
+        <p className="home-tagline">A test project built with Vite + React.</p>
+        <p className="home-description">
+          This is a personal sandbox for experimenting with React — a place to
+          try out components, UI ideas, and small browser apps. Browse the tabs
+          above to explore a fuel calculator, data analytics charts, and a few
+          mini-games like TicTacToe, Minesweeper, and Dice 21.
         </p>
-        <div className="row">
-          <div className="small-12 column">
-            {" "}
-            <div className="my-arrow-div text-center">
-              <a
-                href="https://github.com/greentea524"
-                target="_blank"
-                aria-label="Visit GitHub profile"
-              >
-                <i className="fa fa-github-alt fa-2x"></i>
-              </a>
-              <a
-                href="https://www.twitter.com/davidphong_"
-                target="_blank"
-                aria-label="Visit Twitter profile"
-              >
-                <i className="fa fa-twitter fa-2x"></i>
-              </a>
-            </div>
-          </div>
-        </div>
       </div>
+
+      {loading ? (
+        <output className="spinner-border text-success" aria-live="polite">
+          <span className="sr-only">Loading...</span>
+        </output>
+      ) : (
+        <ProjectLinks />
+      )}
     </div>
   );
 }

--- a/src/component/ProjectLinks.jsx
+++ b/src/component/ProjectLinks.jsx
@@ -1,24 +1,43 @@
-import { useState } from "react";
-
 function ProjectLinks() {
-  const [count, setCount] = useState(0);
-
   return (
-    <div className="container">
-      <div className="row">
-        <div className="small-12 column">
-          <div className="cta text-center">
-            <a
-              className="my-button cta-button"
-              href="https://greentea524.github.io/portfolio/"
-            >
-              <i className="fa fa-folder fa-2x"></i> Portfolio
-            </a>
-          </div>
-        </div>
+    <div className="home-links">
+      <div className="home-buttons">
+        <a
+          className="my-button cta-button"
+          href="https://greentea524.github.io/portfolio/"
+          target="_blank"
+          rel="noreferrer"
+        >
+          <i className="fa fa-folder"></i> Portfolio
+        </a>
+        <a
+          className="my-button cta-button"
+          href="https://greentea524.github.io/"
+          target="_blank"
+          rel="noreferrer"
+        >
+          <i className="fa fa-external-link"></i> Live Site
+        </a>
       </div>
-      <br></br>
 
+      <div className="home-social">
+        <a
+          href="https://github.com/greentea524"
+          target="_blank"
+          rel="noreferrer"
+          aria-label="Visit GitHub profile"
+        >
+          <i className="fa fa-github-alt fa-2x"></i>
+        </a>
+        <a
+          href="https://www.twitter.com/davidphong_"
+          target="_blank"
+          rel="noreferrer"
+          aria-label="Visit Twitter profile"
+        >
+          <i className="fa fa-twitter fa-2x"></i>
+        </a>
+      </div>
     </div>
   );
 }

--- a/src/component/ProjectLinks.jsx
+++ b/src/component/ProjectLinks.jsx
@@ -10,14 +10,6 @@ function ProjectLinks() {
         >
           <i className="fa fa-folder"></i> Portfolio
         </a>
-        <a
-          className="my-button cta-button"
-          href="https://greentea524.github.io/"
-          target="_blank"
-          rel="noreferrer"
-        >
-          <i className="fa fa-external-link"></i> Live Site
-        </a>
       </div>
 
       <div className="home-social">

--- a/src/component/ReactTabHeader.jsx
+++ b/src/component/ReactTabHeader.jsx
@@ -7,6 +7,7 @@ import Minesweeper from "./Minesweeper.jsx";
 import DataAnalytics from "./DataAnalytics.jsx";
 import FuelCalculator from "./FuelCalculator.jsx";
 import DiceBlackjack from "./DiceBlackjack.jsx";
+import Sudoku from "./Sudoku.jsx";
 
 const LOCAL_GAMES = [
   {
@@ -26,6 +27,12 @@ const LOCAL_GAMES = [
     title: "Dice 21",
     icon: "fa-cubes",
     description: "Roll toward 21 without busting in this dice blackjack.",
+  },
+  {
+    key: "sudoku",
+    title: "Sudoku",
+    icon: "fa-table",
+    description: "Fill the colorful 9×9 grid so every row, column, and box has 1–9.",
   },
 ];
 
@@ -81,6 +88,8 @@ class ReactTabHeader extends Component {
         return <Minesweeper />;
       case "dice21":
         return <DiceBlackjack />;
+      case "sudoku":
+        return <Sudoku />;
       default:
         return null;
     }

--- a/src/component/Sudoku.jsx
+++ b/src/component/Sudoku.jsx
@@ -1,0 +1,213 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import "./sudoku.css";
+
+// Valid pre-generated puzzles. Each is 81 chars, row-major, "0" = empty cell.
+// A completed grid with no row/column/box conflicts is, by definition, solved,
+// so win detection does not need a stored solution.
+const PUZZLES = [
+  "530070000600195000098000060800060003400803001700020006060000280000419005000080079",
+  "200080300060070084030500209000105408000000000402706000301007040720040060004010003",
+  "000000907000420180000705026100904000050000040000507009920108000034059000507000000",
+  "100489006730000040000001295007120600500703008006095700914600000020000037800512004",
+];
+
+const SIZE = 9;
+const BOX = 3;
+
+function boxIndex(row, col) {
+  return Math.floor(row / BOX) * BOX + Math.floor(col / BOX);
+}
+
+// Parse an 81-char puzzle string into an array of cell objects.
+function parsePuzzle(puzzle) {
+  return puzzle.split("").map((ch) => {
+    const value = ch === "0" ? "" : ch;
+    return { value, given: value !== "" };
+  });
+}
+
+function pickRandomPuzzle() {
+  return PUZZLES[Math.floor(Math.random() * PUZZLES.length)];
+}
+
+// Returns a Set of cell indices that conflict with another cell sharing the
+// same row, column, or 3×3 box. Empty cells never conflict.
+function findConflicts(cells) {
+  const conflicts = new Set();
+
+  const check = (group) => {
+    const seen = new Map();
+    for (const idx of group) {
+      const value = cells[idx].value;
+      if (!value) continue;
+      if (seen.has(value)) {
+        conflicts.add(idx);
+        conflicts.add(seen.get(value));
+      } else {
+        seen.set(value, idx);
+      }
+    }
+  };
+
+  for (let i = 0; i < SIZE; i++) {
+    const row = [];
+    const col = [];
+    const box = [];
+    for (let j = 0; j < SIZE; j++) {
+      row.push(i * SIZE + j);
+      col.push(j * SIZE + i);
+      // i-th box, j-th cell within that box
+      const r = Math.floor(i / BOX) * BOX + Math.floor(j / BOX);
+      const c = (i % BOX) * BOX + (j % BOX);
+      box.push(r * SIZE + c);
+    }
+    check(row);
+    check(col);
+    check(box);
+  }
+
+  return conflicts;
+}
+
+function Sudoku() {
+  const [cells, setCells] = useState(() => parsePuzzle(pickRandomPuzzle()));
+  const [selected, setSelected] = useState(null);
+
+  const conflicts = useMemo(() => findConflicts(cells), [cells]);
+
+  const isComplete = useMemo(
+    () => cells.every((cell) => cell.value !== ""),
+    [cells]
+  );
+  const hasWon = isComplete && conflicts.size === 0;
+
+  const setCellValue = useCallback((index, value) => {
+    setCells((prev) => {
+      if (prev[index].given) return prev;
+      if (prev[index].value === value) return prev;
+      const next = prev.slice();
+      next[index] = { ...next[index], value };
+      return next;
+    });
+  }, []);
+
+  // Keyboard input for the currently selected cell.
+  useEffect(() => {
+    if (selected === null || hasWon) return undefined;
+
+    const handleKeyDown = (event) => {
+      if (cells[selected].given) return;
+
+      if (event.key >= "1" && event.key <= "9") {
+        setCellValue(selected, event.key);
+        event.preventDefault();
+      } else if (
+        event.key === "Backspace" ||
+        event.key === "Delete" ||
+        event.key === "0"
+      ) {
+        setCellValue(selected, "");
+        event.preventDefault();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [selected, cells, hasWon, setCellValue]);
+
+  const handleCellClick = (index) => {
+    setSelected(index);
+  };
+
+  const handlePadInput = (value) => {
+    if (selected === null || hasWon) return;
+    setCellValue(selected, value);
+  };
+
+  const handleNewGame = () => {
+    setCells(parsePuzzle(pickRandomPuzzle()));
+    setSelected(null);
+  };
+
+  const padDisabled =
+    selected === null || hasWon || cells[selected]?.given === true;
+
+  return (
+    <div className="sudoku">
+      <h3 className="sudoku-title">Sudoku</h3>
+      <p className="sudoku-instructions">
+        Click a cell, then type 1–9. Press Backspace or Delete to clear.
+      </p>
+
+      <div className="sudoku-board" role="grid" aria-label="Sudoku board">
+        {cells.map((cell, index) => {
+          const row = Math.floor(index / SIZE);
+          const col = index % SIZE;
+          const classNames = [
+            "sudoku-cell",
+            `box-${boxIndex(row, col)}`,
+            cell.given ? "given" : "",
+            selected === index ? "selected" : "",
+            conflicts.has(index) ? "conflict" : "",
+            col % BOX === 0 ? "box-left" : "",
+            row % BOX === 0 ? "box-top" : "",
+            col === SIZE - 1 ? "board-right" : "",
+            row === SIZE - 1 ? "board-bottom" : "",
+          ]
+            .filter(Boolean)
+            .join(" ");
+
+          return (
+            <button
+              type="button"
+              key={index}
+              className={classNames}
+              onClick={() => handleCellClick(index)}
+              disabled={hasWon}
+              aria-label={`Row ${row + 1}, column ${col + 1}${
+                cell.value ? `, value ${cell.value}` : ", empty"
+              }`}
+            >
+              {cell.value}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="sudoku-pad" aria-label="Number pad">
+        {["1", "2", "3", "4", "5", "6", "7", "8", "9"].map((digit) => (
+          <button
+            type="button"
+            key={digit}
+            className="sudoku-pad-btn"
+            onClick={() => handlePadInput(digit)}
+            disabled={padDisabled}
+          >
+            {digit}
+          </button>
+        ))}
+        <button
+          type="button"
+          className="sudoku-pad-btn sudoku-pad-erase"
+          onClick={() => handlePadInput("")}
+          disabled={padDisabled}
+          aria-label="Erase cell"
+        >
+          ⌫
+        </button>
+      </div>
+
+      {hasWon && (
+        <div className="sudoku-win" role="status">
+          🎉 You Win! 🎉
+        </div>
+      )}
+
+      <button type="button" className="sudoku-new-game" onClick={handleNewGame}>
+        New Game
+      </button>
+    </div>
+  );
+}
+
+export default Sudoku;

--- a/src/component/Sudoku.jsx
+++ b/src/component/Sudoku.jsx
@@ -1,33 +1,107 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import "./sudoku.css";
 
-// Valid pre-generated puzzles. Each is 81 chars, row-major, "0" = empty cell.
-// A completed grid with no row/column/box conflicts is, by definition, solved,
-// so win detection does not need a stored solution.
-const PUZZLES = [
-  "530070000600195000098000060800060003400803001700020006060000280000419005000080079",
-  "200080300060070084030500209000105408000000000402706000301007040720040060004010003",
-  "000000907000420180000705026100904000050000040000507009920108000034059000507000000",
-  "100489006730000040000001295007120600500703008006095700914600000020000037800512004",
-];
-
 const SIZE = 9;
 const BOX = 3;
+const CELL_COUNT = SIZE * SIZE;
+
+// Difficulty -> number of clues to keep in the generated puzzle. Fewer clues
+// is harder. The digger may stop short of the target if going further would
+// break the puzzle's unique solution.
+const DIFFICULTIES = {
+  easy: 40,
+  medium: 32,
+  hard: 26,
+};
 
 function boxIndex(row, col) {
   return Math.floor(row / BOX) * BOX + Math.floor(col / BOX);
 }
 
-// Parse an 81-char puzzle string into an array of cell objects.
-function parsePuzzle(puzzle) {
-  return puzzle.split("").map((ch) => {
-    const value = ch === "0" ? "" : ch;
-    return { value, given: value !== "" };
-  });
+// Fisher–Yates in-place shuffle.
+function shuffle(arr) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
 }
 
-function pickRandomPuzzle() {
-  return PUZZLES[Math.floor(Math.random() * PUZZLES.length)];
+// Can `value` (1–9) be placed at flat `index` without violating Sudoku rules?
+function canPlace(grid, index, value) {
+  const r = Math.floor(index / SIZE);
+  const c = index % SIZE;
+  for (let k = 0; k < SIZE; k++) {
+    if (grid[r * SIZE + k] === value) return false;
+    if (grid[k * SIZE + c] === value) return false;
+    const br = Math.floor(r / BOX) * BOX + Math.floor(k / BOX);
+    const bc = Math.floor(c / BOX) * BOX + (k % BOX);
+    if (grid[br * SIZE + bc] === value) return false;
+  }
+  return true;
+}
+
+// Fill empty cells (0) with a complete valid solution using randomized
+// backtracking. Mutates and returns true on success.
+function fillGrid(grid) {
+  const index = grid.indexOf(0);
+  if (index === -1) return true;
+  for (const value of shuffle([1, 2, 3, 4, 5, 6, 7, 8, 9])) {
+    if (canPlace(grid, index, value)) {
+      grid[index] = value;
+      if (fillGrid(grid)) return true;
+      grid[index] = 0;
+    }
+  }
+  return false;
+}
+
+function generateSolvedGrid() {
+  const grid = new Array(CELL_COUNT).fill(0);
+  fillGrid(grid);
+  return grid;
+}
+
+// Count solutions of `grid`, stopping early once `limit` is reached. Used to
+// confirm a dug-out puzzle still has exactly one solution.
+function countSolutions(grid, limit) {
+  const index = grid.indexOf(0);
+  if (index === -1) return 1;
+  let count = 0;
+  for (let value = 1; value <= 9 && count < limit; value++) {
+    if (canPlace(grid, index, value)) {
+      grid[index] = value;
+      count += countSolutions(grid, limit - count);
+      grid[index] = 0;
+    }
+  }
+  return count;
+}
+
+// Build a fresh puzzle: start from a full solution, then remove cells one at a
+// time, keeping a removal only if the puzzle still has a unique solution.
+function generatePuzzle(targetClues) {
+  const puzzle = generateSolvedGrid();
+  let clues = CELL_COUNT;
+  for (const index of shuffle([...Array(CELL_COUNT).keys()])) {
+    if (clues <= targetClues) break;
+    const backup = puzzle[index];
+    puzzle[index] = 0;
+    if (countSolutions(puzzle.slice(), 2) === 1) {
+      clues--;
+    } else {
+      puzzle[index] = backup; // removal made the solution ambiguous; keep it
+    }
+  }
+  return puzzle;
+}
+
+// Turn a numeric puzzle grid (0 = empty) into the cell objects used by the UI.
+function buildCells(grid) {
+  return grid.map((value) => ({
+    value: value === 0 ? "" : String(value),
+    given: value !== 0,
+  }));
 }
 
 // Returns a Set of cell indices that conflict with another cell sharing the
@@ -70,7 +144,10 @@ function findConflicts(cells) {
 }
 
 function Sudoku() {
-  const [cells, setCells] = useState(() => parsePuzzle(pickRandomPuzzle()));
+  const [difficulty, setDifficulty] = useState("medium");
+  const [cells, setCells] = useState(() =>
+    buildCells(generatePuzzle(DIFFICULTIES.medium))
+  );
   const [selected, setSelected] = useState(null);
 
   const conflicts = useMemo(() => findConflicts(cells), [cells]);
@@ -124,9 +201,19 @@ function Sudoku() {
     setCellValue(selected, value);
   };
 
-  const handleNewGame = () => {
-    setCells(parsePuzzle(pickRandomPuzzle()));
+  const startNewGame = useCallback((level) => {
+    setCells(buildCells(generatePuzzle(DIFFICULTIES[level])));
     setSelected(null);
+  }, []);
+
+  const handleNewGame = () => {
+    startNewGame(difficulty);
+  };
+
+  const handleDifficultyChange = (event) => {
+    const level = event.target.value;
+    setDifficulty(level);
+    startNewGame(level);
   };
 
   const padDisabled =
@@ -138,6 +225,19 @@ function Sudoku() {
       <p className="sudoku-instructions">
         Click a cell, then type 1–9. Press Backspace or Delete to clear.
       </p>
+
+      <div className="sudoku-difficulty">
+        <label htmlFor="sudoku-difficulty-select">Difficulty</label>
+        <select
+          id="sudoku-difficulty-select"
+          value={difficulty}
+          onChange={handleDifficultyChange}
+        >
+          <option value="easy">Easy</option>
+          <option value="medium">Medium</option>
+          <option value="hard">Hard</option>
+        </select>
+      </div>
 
       <div className="sudoku-board" role="grid" aria-label="Sudoku board">
         {cells.map((cell, index) => {

--- a/src/component/sudoku.css
+++ b/src/component/sudoku.css
@@ -1,0 +1,152 @@
+.sudoku {
+  --cell-size: clamp(32px, 9.5vw, 52px);
+  width: min(100%, 520px);
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem;
+}
+
+.sudoku-title {
+  margin: 0;
+}
+
+.sudoku-instructions {
+  margin: 0;
+  text-align: center;
+  font-size: 0.9rem;
+  opacity: 0.85;
+}
+
+.sudoku-board {
+  display: grid;
+  grid-template-columns: repeat(9, 1fr);
+  grid-template-rows: repeat(9, 1fr);
+  /* Fluid: never wider than the container, capped at the ideal size so the
+     board always fits on small/mobile screens. Square via aspect-ratio. */
+  width: min(100%, calc(var(--cell-size) * 9));
+  aspect-ratio: 1 / 1;
+  border: 3px solid #1f2937;
+  background: #1f2937;
+}
+
+.sudoku-cell {
+  width: 100%;
+  height: 100%;
+  /* Override Windows theme button defaults (min-width/padding) that would
+     stretch cells into non-square rectangles and offset the digits. */
+  min-width: 0;
+  min-height: 0;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  font-size: clamp(1rem, 4.5vw, 1.6rem);
+  font-weight: 500;
+  cursor: pointer;
+  padding: 0;
+  margin: 0;
+  border: 1px solid rgba(31, 41, 55, 0.25);
+  color: #1f2937;
+  transition: background-color 0.12s ease, transform 0.05s ease;
+}
+
+/* Distinct bold accent color per 3×3 box */
+.sudoku-cell.box-0 { background: #fde2e4; }
+.sudoku-cell.box-1 { background: #e2f0cb; }
+.sudoku-cell.box-2 { background: #cde7ff; }
+.sudoku-cell.box-3 { background: #fff1c1; }
+.sudoku-cell.box-4 { background: #e7d6ff; }
+.sudoku-cell.box-5 { background: #d0f4f0; }
+.sudoku-cell.box-6 { background: #ffe0c7; }
+.sudoku-cell.box-7 { background: #fcd5e5; }
+.sudoku-cell.box-8 { background: #d7f9e3; }
+
+/* Thicker borders to delineate the nine 3×3 boxes */
+.sudoku-cell.box-left { border-left: 2px solid #1f2937; }
+.sudoku-cell.box-top { border-top: 2px solid #1f2937; }
+.sudoku-cell.board-right { border-right: 2px solid #1f2937; }
+.sudoku-cell.board-bottom { border-bottom: 2px solid #1f2937; }
+
+.sudoku-cell.given {
+  font-weight: 800;
+  color: #0f172a;
+  cursor: default;
+}
+
+.sudoku-cell.selected {
+  outline: 3px solid #2563eb;
+  outline-offset: -3px;
+  z-index: 1;
+}
+
+.sudoku-cell.conflict {
+  background: #ef4444;
+  color: #fff;
+}
+
+.sudoku-cell:focus {
+  outline: 3px solid #2563eb;
+  outline-offset: -3px;
+}
+
+.sudoku-cell:disabled {
+  cursor: default;
+}
+
+.sudoku-pad {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 0.4rem;
+  width: min(100%, calc(var(--cell-size) * 9));
+}
+
+.sudoku-pad-btn {
+  min-width: 0;
+  padding: 0.5rem 0;
+  font-size: clamp(1.1rem, 4.5vw, 1.5rem);
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.sudoku-pad-btn:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.sudoku-pad-erase {
+  grid-column: span 1;
+}
+
+.sudoku-win {
+  font-size: clamp(1.4rem, 6vw, 2rem);
+  font-weight: 800;
+  text-align: center;
+  padding: 0.5rem 1.25rem;
+  border-radius: 0.75rem;
+  background: linear-gradient(90deg, #ff6b6b, #feca57, #1dd1a1, #54a0ff, #5f27cd);
+  background-size: 300% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: sudoku-celebrate 2s linear infinite;
+}
+
+@keyframes sudoku-celebrate {
+  0% { background-position: 0% 50%; }
+  100% { background-position: 300% 50%; }
+}
+
+.sudoku-new-game {
+  margin-top: 0.25rem;
+}
+
+@media (max-width: 576px) {
+  .sudoku {
+    --cell-size: clamp(30px, 10vw, 40px);
+    width: 100%;
+  }
+}

--- a/src/component/sudoku.css
+++ b/src/component/sudoku.css
@@ -97,6 +97,16 @@
   cursor: default;
 }
 
+.sudoku-difficulty {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.sudoku-difficulty label {
+  font-weight: 600;
+}
+
 .sudoku-pad {
   display: grid;
   grid-template-columns: repeat(5, 1fr);


### PR DESCRIPTION
## Summary
Adds a complete Sudoku mini-game as a fourth card under Games â†’ Mini Games, implementing all of SUD-1 â†’ SUD-7.

- **SUD-1**: colorful 9Ã—9 grid with a distinct accent color per 3Ã—3 box
- **SUD-2**: random pre-generated puzzle with bold, non-editable clue cells
- **SUD-3**: click to select + keyboard 1â€“9 input; Backspace/Delete clears
- **SUD-4**: red highlighting for row/column/box conflicts, clears on removal
- **SUD-5**: win detection with animated "You Win!" celebration
- **SUD-6**: New Game button that loads a fresh puzzle
- **SUD-7**: on-screen number pad for mouse/touch play; fluid responsive board

## Notes
- Win detection is conflict-based (a fully filled, conflict-free grid is solved), so the same logic powers both mistake highlighting and the win check.
- Cells override the Windows theme's button `min-width` to stay square; the board uses a fluid `repeat(9, 1fr)` grid with `aspect-ratio: 1` to fit mobile screens.

## Verification
Verified live in browser preview (desktop + 375px mobile): square centered cells, keyboard + number-pad input, conflict highlighting, win banner, New Game reset, no console errors.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)
